### PR TITLE
fix: prevent shell quoting of tilde in path

### DIFF
--- a/org-logseq.el
+++ b/org-logseq.el
@@ -83,7 +83,7 @@ The type can be 'url, 'draw and 'page, denoting the link type."
     (format (pcase type
               ('page "grep -niR \"^#+\\(TITLE\\|ALIAS\\): *%s\" %s --exclude-dir=.git" )
               ('id "grep -niR \":id: *%s\" %s --exclude-dir=.git"))
-            query (shell-quote-argument org-logseq-dir))))
+            query (shell-quote-argument (f-expand org-logseq-dir)))))
 
 (defun org-logseq-get-block-ref-or-embed-link ()
   (when-let ((ovs (overlays-at (point)))


### PR DESCRIPTION
Expand path from something like "~/notes" to "home/user/notes" so that the tilde char doesn't get shell quoted, which leads to an incorrect file path.